### PR TITLE
21 | Fix compatibility typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ await server.register({
 });
 ```
 
-### Compatability Methods
+### Compatibility Methods
 
-By default goalie uses the npm semver module to determine version compatability. If your request `api-version` is "^v1.0.0" and the api's actual version is "v1.0.2" then goalie will not abort that request. In addition to semver, you can use 'strict' mode which uses strict equality to determine if versions match (requestVersion === apiVersion), or you can provide a callback to resolve version compatibility yourslef.
+By default goalie uses the npm semver module to determine version compatibility. If your request `api-version` is "^v1.0.0" and the api's actual version is "v1.0.2" then goalie will not abort that request. In addition to semver, you can use 'strict' mode which uses strict equality to determine if versions match (requestVersion === apiVersion), or you can provide a callback to resolve version compatibility yourslef.
 
 ```
 // use strict
@@ -35,7 +35,7 @@ await server.register({
   register: Goalie,
   {
     apiVersion: 'v1.0.0',
-    compatabilityMethod: 'strict',
+    compatibilityMethod: 'strict',
   }
 });
 
@@ -45,7 +45,7 @@ await server.register({
   register: Goalie,
   {
     apiVersion: 'v1.0.0',
-    compatabilityMethod: (requestVersion, apiVersion) => {
+    compatibilityMethod: (requestVersion, apiVersion) => {
       // determine whether or not the request version is compatible
       return true; // return false to abort the request and return 412
     },
@@ -58,4 +58,4 @@ await server.register({
 | name | description |
 | ---- | ----------- |
 | apiVersion | The current version of the api |
-| compatibilyMethod | The method that goalie will use to determine version compatability. Defaults to 'semver' |
+| compatibilityMethod | The method that goalie will use to determine version compatibility. Defaults to 'semver' |

--- a/lib/index.js
+++ b/lib/index.js
@@ -15,7 +15,7 @@ const semverResolver = (request, h, options) => {
 };
 
 const callbackResolver = (request, h, options) => {
-  if (options.compatabilityMethod(request.headers['api-version'], options.apiVersion)) {
+  if (options.compatibilityMethod(request.headers['api-version'], options.apiVersion)) {
     return h.continue;
   }
 
@@ -25,7 +25,7 @@ const callbackResolver = (request, h, options) => {
 exports.plugin = {
   pkg: require('../package.json'),
   register: async (server, options) => {
-    const compatabilityMethod = options.compatabilityMethod || 'semver';
+    const compatibilityMethod = options.compatibilityMethod || 'semver';
 
     if (options.apiVersion) {
       server.ext({
@@ -36,9 +36,9 @@ exports.plugin = {
           }
 
           let resolver;
-          if (typeof compatabilityMethod === 'function') {
+          if (typeof compatibilityMethod === 'function') {
             resolver = callbackResolver;
-          } else if (compatabilityMethod === 'strict') {
+          } else if (compatibilityMethod === 'strict') {
             resolver = strictResolver;
           } else {
             resolver = semverResolver;

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,14 +1,16 @@
 const Boom = require('@hapi/boom');
-const semver = require('semver');
+const Semver = require('semver');
 
 const strictResolver = (request, h, options) => {
+
   return request.headers['api-version'] !== options.apiVersion
     ? Boom.preconditionFailed()
     : h.continue;
 };
 
 const semverResolver = (request, h, options) => {
-  if (semver.satisfies(options.apiVersion, request.headers['api-version'])) {
+
+  if (Semver.satisfies(options.apiVersion, request.headers['api-version'])) {
     return h.continue;
   }
 
@@ -16,6 +18,7 @@ const semverResolver = (request, h, options) => {
 };
 
 const callbackResolver = (request, h, options) => {
+
   if (options.compatibilityMethod(request.headers['api-version'], options.apiVersion)) {
     return h.continue;
   }
@@ -26,12 +29,14 @@ const callbackResolver = (request, h, options) => {
 exports.plugin = {
   pkg: require('../package.json'),
   register: async (server, options) => {
+
     const compatibilityMethod = options.compatibilityMethod || 'semver';
 
     if (options.apiVersion) {
       server.ext({
         type: 'onPreHandler',
         method: (request, h) => {
+
           if (!request.headers['api-version']) {
             return h.continue;
           }
@@ -52,6 +57,7 @@ exports.plugin = {
       server.ext({
         type: 'onPreResponse',
         method: (request, h) => {
+
           if (request.response.isBoom) {
             request.response.output.headers['api-version'] = options.apiVersion;
           } else {

--- a/test/index.js
+++ b/test/index.js
@@ -7,6 +7,7 @@ const { describe, it } = exports.lab = require('@hapi/lab').script();
 const Goalie = require('../lib');
 
 const makeServer = async options => {
+
   const server = Hapi.Server({ port: 80 });
   await server.register({
     plugin: Goalie,
@@ -18,13 +19,17 @@ const makeServer = async options => {
 };
 
 describe('smoke test', () => {
+
   it('registers without errors', async () => {
+
     await makeServer({});
   });
 });
 
 describe('Goalie', () => {
+
   it('does nothing if api version is not supplied', async () => {
+
     const server = await makeServer();
     const res = await server.inject('/');
     expect(res.statusCode).to.equal(200);
@@ -32,6 +37,7 @@ describe('Goalie', () => {
   });
 
   it('appends api version response header when api-version request header is not present', async () => {
+
     const apiVersion = 'v1.0.0';
     const server = await makeServer({ apiVersion });
     const res = await server.inject('/');
@@ -41,6 +47,7 @@ describe('Goalie', () => {
   });
 
   it('appends api-version to error response', async () => {
+
     const server = Hapi.Server({ port: 80 });
     await server.register({
       plugin: Goalie,
@@ -55,7 +62,9 @@ describe('Goalie', () => {
   });
 
   describe('strict', () => {
+
     it('appends api version response header when client and api versions match exactly', async () => {
+
       const apiVersion = 'v1.0.0';
       const server = await makeServer({ apiVersion, compatibilityMethod: 'strict' });
       const res = await server.inject({
@@ -68,6 +77,7 @@ describe('Goalie', () => {
     });
 
     it('responds with a 412 when the client and api versions do not match exactly', async () => {
+
       const apiVersion = 'v1.0.0';
       const server = await makeServer({ apiVersion, compatibilityMethod: 'strict' });
       const res = await server.inject({
@@ -81,6 +91,7 @@ describe('Goalie', () => {
   });
 
   describe('semver', () => {
+
     const cases = [{
       apiVersion: 'v1.0.0',
       requestVersion: '^v1.0.0',
@@ -103,6 +114,7 @@ describe('Goalie', () => {
       const testCase = cases[i];
 
       it(`returns ${testCase.code} when apiVersion is ${testCase.apiVersion} and request version is ${testCase.requestVersion}`, async () => {
+
         const server = await makeServer({ apiVersion: testCase.apiVersion });
         const res = await server.inject({
           url: '/',
@@ -115,7 +127,9 @@ describe('Goalie', () => {
   });
 
   describe('callback', () => {
+
     it('calls the callback with request api-version and current api version', async () => {
+
       let called = false;
       let calledValues = {};
 
@@ -125,6 +139,7 @@ describe('Goalie', () => {
       const server = await makeServer({
         apiVersion,
         compatibilityMethod: (testRequestVersion, testApiVersion) => {
+
           called = true;
           calledValues = {
             testApiVersion,
@@ -143,6 +158,7 @@ describe('Goalie', () => {
     });
 
     it('appends api version response header when callback returns true', async () => {
+
       const apiVersion = 'v1.0.0';
       const server = await makeServer({
         apiVersion,
@@ -158,6 +174,7 @@ describe('Goalie', () => {
     });
 
     it('responds with a 412 when the callback returns false', async () => {
+
       const apiVersion = 'v1.0.0';
       const server = await makeServer({
         apiVersion,

--- a/test/index.js
+++ b/test/index.js
@@ -55,7 +55,7 @@ describe('Goalie', () => {
   describe('strict', () => {
     it('appends api version response header when client and api versions match exactly', async () => {
       const apiVersion = 'v1.0.0';
-      const server = await makeServer({ apiVersion, compatabilityMethod: 'strict' });
+      const server = await makeServer({ apiVersion, compatibilityMethod: 'strict' });
       const res = await server.inject({
         url: '/',
         headers: { 'api-version': apiVersion },
@@ -67,7 +67,7 @@ describe('Goalie', () => {
 
     it('responds with a 412 when the client and api versions do not match exactly', async () => {
       const apiVersion = 'v1.0.0';
-      const server = await makeServer({ apiVersion, compatabilityMethod: 'strict' });
+      const server = await makeServer({ apiVersion, compatibilityMethod: 'strict' });
       const res = await server.inject({
         url: '/',
         headers: { 'api-version': 'not-v1.0.0' },
@@ -122,7 +122,7 @@ describe('Goalie', () => {
 
       const server = await makeServer({
         apiVersion,
-        compatabilityMethod: (testRequestVersion, testApiVersion) => {
+        compatibilityMethod: (testRequestVersion, testApiVersion) => {
           called = true;
           calledValues = {
             testApiVersion,
@@ -144,7 +144,7 @@ describe('Goalie', () => {
       const apiVersion = 'v1.0.0';
       const server = await makeServer({
         apiVersion,
-        compatabilityMethod: () => true,
+        compatibilityMethod: () => true,
       });
 
       const res = await server.inject({
@@ -159,7 +159,7 @@ describe('Goalie', () => {
       const apiVersion = 'v1.0.0';
       const server = await makeServer({
         apiVersion,
-        compatabilityMethod: () => false,
+        compatibilityMethod: () => false,
       });
 
       const res = await server.inject({


### PR DESCRIPTION
Fixes #21 

This is a breaking change, as any projects using the incorrectly-spelled `compatabilityMethod` will need to be updated. 